### PR TITLE
Allow setting custom thumbnails in prefs

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -32,14 +32,20 @@ def MainMenu():
     i=1
 
     while Prefs['url'+str(i)] and Prefs['title'+str(i)] :
-        oc.add(CreateTrackObject(url=Prefs['url'+str(i)], title=Prefs['title'+str(i)], fmt=Prefs['type'+str(i)]))
+        try:
+            thumb = Prefs['thumb'+str(i)]
+        except KeyError:
+            thumb = ''
+        thumb = thumb if thumb else R(ICON)
+        oc.add(CreateTrackObject(url=Prefs['url'+str(i)], title=Prefs['title'+str(i)], fmt=Prefs['type'+str(i)],
+                                 thumb=thumb))
         i += 1
 
     return oc
 
 
 ####################################################################################################
-def CreateTrackObject(url, title, fmt, include_container=False, includeBandwidths=False):
+def CreateTrackObject(url, title, fmt, thumb, include_container=False, includeBandwidths=False):
       
 	# choose container and codec to use for the supplied format
     if fmt == 'mp3':
@@ -68,7 +74,7 @@ def CreateTrackObject(url, title, fmt, include_container=False, includeBandwidth
         key=Callback(CreateTrackObject, url=url, title=title, fmt=fmt, include_container=True, includeBandwidths=False),
         rating_key=url,
         title=title,
-        thumb=R(ICON),
+        thumb=thumb,
         items=[
             MediaObject(
                 parts=[

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -2,40 +2,50 @@
   {"id":"title1",  "label": "Stream 1: Name",       "type": "text", "default": "BBC World Service"},
   {"id":"url1",    "label": "Stream 1: URL",        "type": "text", "default": "http://bbcwssc.ic.llnwd.net/stream/bbcwssc_mp1_ws-eieuk"},
   {"id":"type1",   "label": "Stream 1: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb1",  "label": "Stream 1: Thumb",      "type": "text", "default": "https://upload.wikimedia.org/wikipedia/commons/e/eb/BBC.svg"},
 
   {"id":"title2",  "label": "Stream 2: Name",       "type": "text", "default": ""},
   {"id":"url2",    "label": "Stream 2: URL",        "type": "text", "default": ""},
   {"id":"type2",   "label": "Stream 2: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb2",  "label": "Stream 2: Thumb",      "type": "text", "default": ""},
 
   {"id":"title3",  "label": "Stream 3: Name",       "type": "text", "default": ""},
   {"id":"url3",    "label": "Stream 3: URL",        "type": "text", "default": ""},
   {"id":"type3",   "label": "Stream 3: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb3",  "label": "Stream 3: Thumb",      "type": "text", "default": ""},
 
   {"id":"title4",  "label": "Stream 4: Name",       "type": "text", "default": ""},
   {"id":"url4",    "label": "Stream 4: URL",        "type": "text", "default": ""},
   {"id":"type4",   "label": "Stream 4: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb4",  "label": "Stream 4: Thumb",      "type": "text", "default": ""},
 
   {"id":"title5",  "label": "Stream 5: Name",       "type": "text", "default": ""},
   {"id":"url5",    "label": "Stream 5: URL",        "type": "text", "default": ""},
   {"id":"type5",   "label": "Stream 5: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb5",  "label": "Stream 5: Thumb",      "type": "text", "default": ""},
 
   {"id":"title6",  "label": "Stream 6: Name",       "type": "text", "default": ""},
   {"id":"url6",    "label": "Stream 6: URL",        "type": "text", "default": ""},
   {"id":"type6",   "label": "Stream 6: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb6",  "label": "Stream 6: Thumb",      "type": "text", "default": ""},
 
   {"id":"title7",  "label": "Stream 7: Name",       "type": "text", "default": ""},
   {"id":"url7",    "label": "Stream 7: URL",        "type": "text", "default": ""},
   {"id":"type7",   "label": "Stream 7: Media Type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb7",  "label": "Stream 7: Thumb",      "type": "text", "default": ""},
 
   {"id":"title8",  "label": "Stream 8: Name",       "type": "text", "default": ""},
   {"id":"url8",    "label": "Stream 8: URL",        "type": "text", "default": ""},
   {"id":"type8",   "label": "Stream 8: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb8",  "label": "Stream 8: Thumb",      "type": "text", "default": ""},
 
   {"id":"title9",  "label": "Stream 9: Name",       "type": "text", "default": ""},
   {"id":"url9",    "label": "Stream 9: URL",        "type": "text", "default": ""},
   {"id":"type9",   "label": "Stream 9: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb9",  "label": "Stream 9: Thumb",      "type": "text", "default": ""},
 
   {"id":"title10",  "label": "Stream 10: Name",       "type": "text", "default": ""},
   {"id":"url10",    "label": "Stream 10: URL",        "type": "text", "default": ""},
-  {"id":"type10",   "label": "Stream 10: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]}
+  {"id":"type10",   "label": "Stream 10: Media type", "type": "enum", "default": "mp3", "values":["mp3","aac","flac","ogg"]},
+  {"id":"thumb10",  "label": "Stream 10: Thumb",      "type": "text", "default": ""}
 ]


### PR DESCRIPTION
This seems to allow setting custom artwork for stations, solving #1.

Of course, the thumbnail I set for the default BBC stream doesn't seem to work for me, but I don't know that Plex can use svg files, so maybe that's why. It does properly display a jpg logo for a different station I've added to mine.

I also don't know if you can use local images or just web images.

It might be better to reorder the preferences to put the format below the thumb because it works as a nice separator.

It could be nice if there was a way to set it like a traditional album, but I don't know how to do that.